### PR TITLE
Fix feed times displaying in UTC instead of local time

### DIFF
--- a/components/feed/feedTopStats.tsx
+++ b/components/feed/feedTopStats.tsx
@@ -1,4 +1,4 @@
-import { formatOutputTime } from "@/lib/utils"
+import { formatDuration, formatOutputTime } from "@/lib/utils"
 import { Card } from "../ui/Card"
 
 type FeedTopStatsProps = {
@@ -9,6 +9,7 @@ type FeedTopStatsProps = {
     feeds: Array<{
       foodId: number
       amount: number
+      feedTime?: string
       food: {
         emoji: string
       }
@@ -41,7 +42,7 @@ export default function FeedTopStats({ stats, medianTimeDifference }: FeedTopSta
       <div className="flex justify-between items-center border-b border-bg-elevated pb-4">
         <h4 className="text-text-secondary font-medium">Poslední jídlo</h4>
         <div className="text-xl font-bold text-text-primary">
-          {lastFeedTime ? new Date(lastFeedTime).toUTCString().split(' ')[4].substring(0, 5) : '--:--'}
+          {lastFeedTime ? formatOutputTime(new Date(lastFeedTime)) : '--:--'}
         </div>
       </div>
 
@@ -78,7 +79,7 @@ export default function FeedTopStats({ stats, medianTimeDifference }: FeedTopSta
         </div>
         <div className="text-right">
           <h4 className="text-xs text-text-secondary font-medium mb-1">Průměrná pauza</h4>
-          <p className="text-lg font-bold text-text-primary">{formatOutputTime(new Date(medianTimeDifference))}</p>
+          <p className="text-lg font-bold text-text-primary">{formatDuration(medianTimeDifference)}</p>
         </div>
       </div>
     </Card>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -3,15 +3,24 @@ export function formatOutputTime(time: Date) {
   if (isNaN(date.getTime())) {
     return "-";
   }
-  // Convert the date to Prague timezone
-  const pragueDate = new Date(
-    date.getTime() + date.getTimezoneOffset() * 60000
-  );
-  return pragueDate.toLocaleTimeString("cs-CZ", {
+  // The stored value is a UTC instant; toLocaleTimeString renders it
+  // in the device's local timezone without any manual offset math.
+  return date.toLocaleTimeString("cs-CZ", {
     hour: "2-digit",
     minute: "2-digit",
     hour12: false,
   });
+}
+
+// Format a duration in milliseconds as HH:mm (e.g. average pause between feeds)
+export function formatDuration(durationMs: number) {
+  if (!Number.isFinite(durationMs) || durationMs < 0) {
+    return "-";
+  }
+  const totalMinutes = Math.floor(durationMs / 60000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
 }
 
 // Get device timezone from browser as string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When a user in Prague (UTC+2) entered a feeding at 10:00, it was saved correctly but displayed as 8:00 in the app.

## Root cause

Saving was already correct — `AddFeedSheet` converts the local `datetime-local` value to a proper UTC instant via `toISOString()` (10:00 Prague → `08:00Z` in the DB). The bug was on the display side:

1. `formatOutputTime` in `lib/utils.ts` shifted the date by `getTimezoneOffset()` before formatting, which effectively rendered the **UTC** wall time instead of the device's local time — exactly a 2-hour error in Prague during DST.
2. The "Poslední jídlo" stat in `feedTopStats.tsx` extracted the time from `toUTCString()`, also showing UTC.

## Fix

- `formatOutputTime` now just calls `toLocaleTimeString("cs-CZ", ...)` on the stored UTC instant, which renders it in the device's local timezone — no manual offset math.
- "Poslední jídlo" uses `formatOutputTime` instead of `toUTCString()`.
- "Průměrná pauza" (a duration in milliseconds, not a timestamp) previously relied on the broken offset hack to display correctly; it now uses a new `formatDuration` helper that formats milliseconds as `HH:mm`.

## Verification

Simulated with `TZ=Europe/Prague`: a feed stored as `2026-06-11T08:00:00.000Z` now displays as `10:00`, and a 3.5h average pause displays as `03:30`. Pre-existing TypeScript errors on `main` are unrelated to the touched files.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ea1bf21-bd8f-43f1-af1d-efce8ea1d44d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ea1bf21-bd8f-43f1-af1d-efce8ea1d44d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

