### PR TITLE
Add editing of feed records and delete confirmation

### DIFF
--- a/components/feed/feedItem.tsx
+++ b/components/feed/feedItem.tsx
@@ -3,7 +3,8 @@ import { formatOutputTime } from '@/lib/utils'
 import { trpc } from '@/trpc/client'
 import { Card } from '../ui/Card'
 import { motion, AnimatePresence } from 'framer-motion'
-import { FaTrash } from 'react-icons/fa6'
+import { FaTrash, FaPen } from 'react-icons/fa6'
+import { format } from 'date-fns'
 
 interface FeedItemProps {
   feed: {
@@ -29,18 +30,66 @@ interface FeedItemProps {
 
 export default function FeedItem({ feed }: FeedItemProps) {
   const [isExpanded, setIsExpanded] = useState(false)
+  const [isEditing, setIsEditing] = useState(false)
+  const [editFeedTime, setEditFeedTime] = useState('')
+  const [editAmount, setEditAmount] = useState(feed.amount)
+  const [editType, setEditType] = useState(feed.type)
+  const [editFoodId, setEditFoodId] = useState(feed.foodId)
+
   const utils = trpc.useUtils()
-  
+
+  const { data: foods } = trpc.food.list.useQuery(undefined, {
+    enabled: isEditing,
+  })
+
   const deleteFeed = trpc.feed.delete.useMutation({
     onSuccess: () => {
       utils.feed.getStats.invalidate()
+      utils.baby.getById.invalidate()
+    }
+  })
+
+  const updateFeed = trpc.feed.update.useMutation({
+    onSuccess: () => {
+      utils.feed.getStats.invalidate()
+      utils.baby.getById.invalidate()
+      setIsEditing(false)
+      setIsExpanded(false)
     }
   })
 
   const handleDelete = (e: React.MouseEvent) => {
     e.stopPropagation()
+    if (!window.confirm('Opravdu smazat toto krmení?')) return
     deleteFeed.mutate({ id: feed.id })
   }
+
+  const startEditing = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    setEditFeedTime(format(new Date(feed.feedTime), "yyyy-MM-dd'T'HH:mm"))
+    setEditAmount(feed.amount)
+    setEditType(feed.type)
+    setEditFoodId(feed.foodId)
+    setIsEditing(true)
+  }
+
+  const handleUpdate = (e: React.FormEvent) => {
+    e.preventDefault()
+    updateFeed.mutate({
+      id: feed.id,
+      feedTime: new Date(editFeedTime).toISOString(),
+      amount: Number(editAmount),
+      type: editType as 'main' | 'additional',
+      foodId: Number(editFoodId),
+    })
+  }
+
+  // Sort foods: milk (id: 4) first
+  const sortedFoods = foods ? [...foods].sort((a, b) => {
+    if (a.id === 4) return -1
+    if (b.id === 4) return 1
+    return 0
+  }) : []
 
   const isMain = feed.type === 'main'
 
@@ -88,17 +137,101 @@ export default function FeedItem({ feed }: FeedItemProps) {
             animate={{ height: 'auto', opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
             className="border-t border-bg-elevated/50"
+            onClick={(e) => e.stopPropagation()}
           >
-            <div className="p-3 flex justify-end bg-error/5">
-              <button
-                onClick={handleDelete}
-                disabled={deleteFeed.isPending}
-                className="flex items-center gap-2 px-4 py-2 bg-error text-white rounded-lg text-sm font-bold active:scale-95 transition-transform disabled:opacity-50"
-              >
-                <FaTrash />
-                {deleteFeed.isPending ? 'Mažu...' : 'Smazat krmení'}
-              </button>
-            </div>
+            {isEditing ? (
+              <form onSubmit={handleUpdate} className="p-4 space-y-4 cursor-default">
+                <div className="space-y-1.5">
+                  <label className="block text-sm font-medium text-text-secondary">Čas krmení</label>
+                  <input
+                    type="datetime-local"
+                    required
+                    value={editFeedTime}
+                    onChange={(e) => setEditFeedTime(e.target.value)}
+                    className="w-full p-3 rounded-xl bg-bg-elevated text-text-primary border-none focus:ring-2 focus:ring-accent-primary outline-none"
+                  />
+                </div>
+
+                <div className="flex gap-4">
+                  <div className="space-y-1.5 flex-1">
+                    <label className="block text-sm font-medium text-text-secondary">Množství</label>
+                    <input
+                      type="number"
+                      required
+                      min={1}
+                      value={editAmount}
+                      onChange={(e) => setEditAmount(Number(e.target.value))}
+                      className="w-full p-3 rounded-xl bg-bg-elevated text-text-primary border-none focus:ring-2 focus:ring-accent-primary outline-none"
+                    />
+                  </div>
+
+                  <div className="space-y-1.5 flex-1">
+                    <label className="block text-sm font-medium text-text-secondary">Jídlo</label>
+                    <select
+                      required
+                      value={editFoodId}
+                      onChange={(e) => setEditFoodId(Number(e.target.value))}
+                      className="w-full p-3 rounded-xl bg-bg-elevated text-text-primary border-none focus:ring-2 focus:ring-accent-primary outline-none"
+                    >
+                      {sortedFoods.map((food) => (
+                        <option key={food.id} value={food.id}>
+                          {food.emoji} {food.name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+
+                <div className="space-y-1.5">
+                  <label className="block text-sm font-medium text-text-secondary">Typ</label>
+                  <select
+                    required
+                    value={editType}
+                    onChange={(e) => setEditType(e.target.value)}
+                    className="w-full p-3 rounded-xl bg-bg-elevated text-text-primary border-none focus:ring-2 focus:ring-accent-primary outline-none"
+                  >
+                    <option value="main">Hlavní chod</option>
+                    <option value="additional">Doplněk</option>
+                  </select>
+                </div>
+
+                <div className="flex justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setIsEditing(false)}
+                    disabled={updateFeed.isPending}
+                    className="px-4 py-2 bg-bg-elevated text-text-secondary rounded-lg text-sm font-bold active:scale-95 transition-transform disabled:opacity-50"
+                  >
+                    Zrušit
+                  </button>
+                  <button
+                    type="submit"
+                    disabled={updateFeed.isPending}
+                    className="px-4 py-2 bg-accent-primary text-white rounded-lg text-sm font-bold active:scale-95 transition-transform disabled:opacity-50"
+                  >
+                    {updateFeed.isPending ? 'Ukládám...' : 'Uložit změny'}
+                  </button>
+                </div>
+              </form>
+            ) : (
+              <div className="p-3 flex justify-end gap-2 bg-error/5">
+                <button
+                  onClick={startEditing}
+                  className="flex items-center gap-2 px-4 py-2 bg-bg-elevated text-text-primary rounded-lg text-sm font-bold active:scale-95 transition-transform"
+                >
+                  <FaPen />
+                  Upravit
+                </button>
+                <button
+                  onClick={handleDelete}
+                  disabled={deleteFeed.isPending}
+                  className="flex items-center gap-2 px-4 py-2 bg-error text-white rounded-lg text-sm font-bold active:scale-95 transition-transform disabled:opacity-50"
+                >
+                  <FaTrash />
+                  {deleteFeed.isPending ? 'Mažu...' : 'Smazat krmení'}
+                </button>
+              </div>
+            )}
           </motion.div>
         )}
       </AnimatePresence>

--- a/server/routers/feed.ts
+++ b/server/routers/feed.ts
@@ -152,6 +152,34 @@ export const feedRouter = router({
       })
     }),
 
+  update: publicProcedure
+    .input(
+      z.object({
+        id: z.number(),
+        feedTime: z.string(),
+        amount: z.number(),
+        type: z.enum(['main', 'additional']),
+        foodId: z.number(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const feedTime = new Date(input.feedTime)
+
+      if (isNaN(feedTime.getTime())) {
+        throw new Error('Neplatný čas krmení')
+      }
+
+      return ctx.prisma.feed.update({
+        where: { id: input.id },
+        data: {
+          feedTime,
+          amount: input.amount,
+          type: input.type,
+          foodId: input.foodId,
+        },
+      })
+    }),
+
   delete: publicProcedure
     .input(z.object({ id: z.number() }))
     .mutation(async ({ ctx, input }) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds the ability to edit an existing feed record and makes deletion safer.

### Server (`server/routers/feed.ts`)

- New `feed.update` tRPC mutation that updates `feedTime`, `amount`, `type` and `foodId` for a given feed id, with the same feed-time validation as `create`.

### Client (`components/feed/feedItem.tsx`)

- Tapping a feed item still expands it; the expanded panel now shows **Upravit** (edit) next to **Smazat** (delete).
- **Upravit** opens an inline edit form pre-filled with the current values: feed time (`datetime-local` in local time, converted to UTC via `toISOString()` on save — consistent with the add-feed flow), amount, food and type, with save/cancel buttons.
- **Smazat** now asks for confirmation (`confirm`) before deleting, preventing accidental deletion on tap.
- Both delete and update invalidate `feed.getStats` and `baby.getById` so stats refresh immediately.
- The food list is fetched only when the edit form is open (`enabled: isEditing`).

## Verification

- `tsc --noEmit` produces the exact same set of errors as `main` (pre-existing, unrelated) — no new type errors introduced.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ea1bf21-bd8f-43f1-af1d-efce8ea1d44d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ea1bf21-bd8f-43f1-af1d-efce8ea1d44d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

