### PR TITLE
Add edit and delete controls for milk measurements

### DIFF
--- a/app/babies/[id]/feedings/page.tsx
+++ b/app/babies/[id]/feedings/page.tsx
@@ -20,7 +20,7 @@ export default function FeedingsPage({
          <PageHeader title="Historie krmení" subtitle={baby?.name} />
 
          <div className="p-4">
-            <FeedSection babyId={babyId} />
+            <FeedSection babyId={babyId} type="full" />
          </div>
       </div>
    )

--- a/app/babies/[id]/measurements/page.tsx
+++ b/app/babies/[id]/measurements/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, use } from 'react'
+import type { FormEvent } from 'react'
 import { trpc } from '@/trpc/client'
 import { Card } from '@/components/ui/Card'
 import { Button } from '@/components/ui/Button'
@@ -19,23 +20,50 @@ export default function MeasurementsPage({
    const [weight, setWeight] = useState('')
    const [height, setHeight] = useState('')
    const [isCreating, setIsCreating] = useState(false)
+   const [editingMeasurementId, setEditingMeasurementId] = useState<number | null>(null)
+   const [editWeight, setEditWeight] = useState('')
+   const [editHeight, setEditHeight] = useState('')
 
    const utils = trpc.useUtils()
    const { data: baby } = trpc.baby.getById.useQuery({ id: babyId })
    const { data: measurements, isLoading } = trpc.measurement.list.useQuery({ babyId })
 
+   const resetCreateForm = () => {
+      setWeight('')
+      setHeight('')
+      setIsCreating(false)
+   }
+
+   const resetEditForm = () => {
+      setEditingMeasurementId(null)
+      setEditWeight('')
+      setEditHeight('')
+   }
+
    const createMeasurement = trpc.measurement.create.useMutation({
       onSuccess: () => {
-         utils.measurement.list.invalidate()
-         setWeight('')
-         setHeight('')
-         setIsCreating(false)
+         void utils.measurement.list.invalidate({ babyId })
+         void utils.baby.getById.invalidate({ id: babyId })
+         resetCreateForm()
+      }
+   })
+
+   const updateMeasurement = trpc.measurement.update.useMutation({
+      onSuccess: () => {
+         void utils.measurement.list.invalidate({ babyId })
+         void utils.baby.getById.invalidate({ id: babyId })
+         resetEditForm()
       }
    })
 
    const deleteMeasurement = trpc.measurement.delete.useMutation({
-      onSuccess: () => {
-         utils.measurement.list.invalidate()
+      onSuccess: (_data, variables) => {
+         void utils.measurement.list.invalidate({ babyId })
+         void utils.baby.getById.invalidate({ id: babyId })
+
+         if (editingMeasurementId === variables.id) {
+            resetEditForm()
+         }
       }
    })
 
@@ -49,12 +77,39 @@ export default function MeasurementsPage({
 
    const latestMeasurement = measurements?.[0]
 
-   const handleSubmit = (e: React.FormEvent) => {
+   const startEditing = (measurement: NonNullable<typeof measurements>[number]) => {
+      setEditingMeasurementId(measurement.id)
+      setEditWeight(String(measurement.weight))
+      setEditHeight(String(measurement.height))
+      setIsCreating(false)
+   }
+
+   const handleDelete = (measurementId: number) => {
+      if (confirm('Smazat měření?')) {
+         deleteMeasurement.mutate({ id: measurementId })
+      }
+   }
+
+   const handleSubmit = (e: FormEvent) => {
       e.preventDefault()
       createMeasurement.mutate({
          babyId,
          weight: Number(weight),
          height: Number(height),
+      })
+   }
+
+   const handleUpdateSubmit = (e: FormEvent) => {
+      e.preventDefault()
+
+      if (editingMeasurementId === null) {
+         return
+      }
+
+      updateMeasurement.mutate({
+         id: editingMeasurementId,
+         weight: Number(editWeight),
+         height: Number(editHeight),
       })
    }
 
@@ -81,6 +136,27 @@ export default function MeasurementsPage({
                         <span className="text-text-muted text-xs font-medium uppercase">Doporučená dávka</span>
                         <span className="text-lg font-bold text-text-primary">{Math.round(latestMeasurement.averageFeedAmount)} ml</span>
                      </div>
+                     <div className="col-span-2 flex gap-2">
+                        <Button
+                           type="button"
+                           variant="secondary"
+                           size="sm"
+                           className="flex-1"
+                           onClick={() => startEditing(latestMeasurement)}
+                        >
+                           Upravit
+                        </Button>
+                        <Button
+                           type="button"
+                           variant="danger"
+                           size="sm"
+                           className="flex-1"
+                           disabled={deleteMeasurement.isPending}
+                           onClick={() => handleDelete(latestMeasurement.id)}
+                        >
+                           Smazat
+                        </Button>
+                     </div>
                   </div>
                ) : (
                   <div className="text-center py-6 text-text-muted">
@@ -90,7 +166,54 @@ export default function MeasurementsPage({
             </Card>
 
             {/* Add Measurement */}
-            {!isCreating ? (
+            {editingMeasurementId !== null ? (
+               <Card className="p-5">
+                  <h2 className="text-lg font-bold mb-4">Upravit měření</h2>
+                  <form onSubmit={handleUpdateSubmit} className="space-y-4">
+                     <div>
+                        <label className="block text-sm font-medium text-text-secondary mb-1.5">Váha (g)</label>
+                        <input
+                           type="number"
+                           required
+                           value={editWeight}
+                           onChange={(e) => setEditWeight(e.target.value)}
+                           className="w-full p-3 rounded-xl bg-bg-elevated text-text-primary border-none focus:ring-2 focus:ring-accent-primary outline-none"
+                           placeholder="Např. 4500"
+                        />
+                     </div>
+                     <div>
+                        <label className="block text-sm font-medium text-text-secondary mb-1.5">Délka (cm)</label>
+                        <input
+                           type="number"
+                           step="0.1"
+                           required
+                           value={editHeight}
+                           onChange={(e) => setEditHeight(e.target.value)}
+                           className="w-full p-3 rounded-xl bg-bg-elevated text-text-primary border-none focus:ring-2 focus:ring-accent-primary outline-none"
+                           placeholder="Např. 56.5"
+                        />
+                     </div>
+                     <div className="flex gap-3 pt-2">
+                        <Button
+                           type="button"
+                           variant="secondary"
+                           className="flex-1"
+                           onClick={resetEditForm}
+                        >
+                           Zrušit
+                        </Button>
+                        <Button
+                           type="submit"
+                           variant="primary"
+                           className="flex-1"
+                           loading={updateMeasurement.isPending}
+                        >
+                           Uložit změny
+                        </Button>
+                     </div>
+                  </form>
+               </Card>
+            ) : !isCreating ? (
                <Button 
                   variant="primary" 
                   className="w-full"
@@ -151,23 +274,39 @@ export default function MeasurementsPage({
             <div className="space-y-3">
                <h3 className="text-lg font-bold px-1 mt-8 mb-2">Historie</h3>
                {measurements?.map((m) => (
-                  <Card key={m.id} className="p-4 flex items-center justify-between group">
-                     <div>
-                        <p className="font-semibold text-text-primary">{format(new Date(m.createdAt), 'd. MMMM yyyy', { locale: cs })}</p>
-                        <p className="text-sm text-text-secondary">
-                           {m.weight} g • {m.height} cm
-                        </p>
+                  <Card
+                     key={m.id}
+                     className={`p-4 ${editingMeasurementId === m.id ? 'ring-2 ring-accent-primary' : ''}`}
+                  >
+                     <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                           <p className="font-semibold text-text-primary">{format(new Date(m.createdAt), 'd. MMMM yyyy', { locale: cs })}</p>
+                           <p className="text-sm text-text-secondary">
+                              {m.weight} g • {m.height} cm
+                           </p>
+                        </div>
+                        <div className="flex gap-2">
+                           <Button
+                              type="button"
+                              variant="secondary"
+                              size="sm"
+                              className="flex-1 sm:flex-none"
+                              onClick={() => startEditing(m)}
+                           >
+                              Upravit
+                           </Button>
+                           <Button
+                              type="button"
+                              variant="danger"
+                              size="sm"
+                              className="flex-1 sm:flex-none"
+                              disabled={deleteMeasurement.isPending}
+                              onClick={() => handleDelete(m.id)}
+                           >
+                              Smazat
+                           </Button>
+                        </div>
                      </div>
-                     <button 
-                        onClick={() => {
-                           if(confirm('Smazat měření?')) {
-                              deleteMeasurement.mutate({ id: m.id })
-                           }
-                        }}
-                        className="text-error opacity-0 group-hover:opacity-100 transition-opacity p-2"
-                     >
-                        Smazat
-                     </button>
                   </Card>
                ))}
                

--- a/components/feed/FeedSection.tsx
+++ b/components/feed/FeedSection.tsx
@@ -3,36 +3,17 @@ import { useState } from "react";
 import { format } from "date-fns";
 import { DayPicker } from "../DatePicker";
 import FeedList from "./feedList";
+import type { FeedListItem } from "./feedItem";
 import FeedTopStats from "./feedTopStats";
 import { trpc } from "@/trpc/client";
 import { getDeviceTimeZone } from "@/lib/utils";
 import { motion, AnimatePresence } from "framer-motion";
 
-type Feed = {
-  id: number;
-  feedTime: string;
-  amount: number;
-  type: string;
-  foodId: number;
-  food: {
-    name: string;
-    emoji: string;
-    unit: {
-      name: string;
-      emoji: string;
-    };
-  };
-  timeSinceLastFeed: string;
-  createdAt: string;
-  updatedAt: string;
-  babyId: number;
-};
-
 type StatsType = {
-  timeSinceLastFeed: string;
+  timeSinceLastFeed: string | null;
   totalMilk: number;
   feedCount: number;
-  feeds: Feed[];
+  feeds: FeedListItem[];
 };
 
 export function FeedSection({
@@ -59,7 +40,7 @@ export function FeedSection({
   // Calculate median time difference
   const medianTimeDifference =
     currentStats?.feeds && currentStats.feeds.length > 1
-      ? currentStats.feeds.reduce((total: number, feed: Feed, index: number) => {
+      ? currentStats.feeds.reduce((total: number, feed: FeedListItem, index: number) => {
           if (index === 0) return 0;
           const timeDiff =
             new Date(feed.feedTime).getTime() -

--- a/components/feed/feedItem.tsx
+++ b/components/feed/feedItem.tsx
@@ -1,44 +1,96 @@
 import { useState } from 'react'
+import type { FormEvent } from 'react'
+import { format } from 'date-fns'
 import { formatOutputTime } from '@/lib/utils'
 import { trpc } from '@/trpc/client'
 import { Card } from '../ui/Card'
-import { motion, AnimatePresence } from 'framer-motion'
-import { FaTrash } from 'react-icons/fa6'
+import { Button } from '../ui/Button'
+import { SegmentedControl } from '../ui/SegmentedControl'
 
 interface FeedItemProps {
-  feed: {
-    id: number
-    createdAt: string
-    updatedAt: string
-    babyId: number
-    feedTime: string
-    amount: number
-    type: string
-    foodId: number
-    food: {
+  feed: FeedListItem
+}
+
+export type FeedListItem = {
+  id: number
+  createdAt: string
+  updatedAt: string
+  babyId: number
+  feedTime: string
+  amount: number
+  type: string
+  foodId: number
+  food: {
+    name: string
+    emoji: string | null
+    unit: {
       name: string
-      emoji: string
-      unit: {
-        name: string
-        emoji: string
-      }
-    }
-    timeSinceLastFeed: string
+      emoji: string | null
+    } | null
   }
+  timeSinceLastFeed: string | null
 }
 
 export default function FeedItem({ feed }: FeedItemProps) {
-  const [isExpanded, setIsExpanded] = useState(false)
+  const [isEditing, setIsEditing] = useState(false)
+  const [editFeedTime, setEditFeedTime] = useState(() =>
+    format(new Date(feed.feedTime), "yyyy-MM-dd'T'HH:mm")
+  )
+  const [editAmount, setEditAmount] = useState(feed.amount)
+  const [editType, setEditType] = useState(feed.type)
+  const [editFoodId, setEditFoodId] = useState(feed.foodId)
+
   const utils = trpc.useUtils()
+  const { data: foods } = trpc.food.list.useQuery()
+
+  const resetEditForm = () => {
+    setIsEditing(false)
+    setEditFeedTime(format(new Date(feed.feedTime), "yyyy-MM-dd'T'HH:mm"))
+    setEditAmount(feed.amount)
+    setEditType(feed.type)
+    setEditFoodId(feed.foodId)
+  }
+
+  const sortedFoods = foods
+    ? [...foods].sort((a, b) => {
+        if (a.id === 4) return -1
+        if (b.id === 4) return 1
+        return 0
+      })
+    : []
   
-  const deleteFeed = trpc.feed.delete.useMutation({
+  const updateFeed = trpc.feed.update.useMutation({
     onSuccess: () => {
-      utils.feed.getStats.invalidate()
+      void utils.feed.getStats.invalidate()
+      void utils.baby.getById.invalidate({ id: feed.babyId })
+      setIsEditing(false)
     }
   })
 
-  const handleDelete = (e: React.MouseEvent) => {
-    e.stopPropagation()
+  const deleteFeed = trpc.feed.delete.useMutation({
+    onSuccess: () => {
+      void utils.feed.getStats.invalidate()
+      void utils.baby.getById.invalidate({ id: feed.babyId })
+    }
+  })
+
+  const handleUpdate = (e: FormEvent) => {
+    e.preventDefault()
+
+    updateFeed.mutate({
+      id: feed.id,
+      feedTime: new Date(editFeedTime).toISOString(),
+      amount: Number(editAmount),
+      type: editType as 'main' | 'additional',
+      foodId: Number(editFoodId),
+    })
+  }
+
+  const handleDelete = () => {
+    if (!confirm('Smazat krmení?')) {
+      return
+    }
+
     deleteFeed.mutate({ id: feed.id })
   }
 
@@ -46,14 +98,13 @@ export default function FeedItem({ feed }: FeedItemProps) {
 
   return (
     <Card 
-      variant={isMain ? 'elevated' : 'flat'}
-      className={`mb-3 overflow-hidden cursor-pointer transition-colors ${
+      variant={isMain ? 'elevated' : 'default'}
+      className={`mb-3 overflow-hidden transition-colors ${
         !isMain ? 'bg-bg-elevated' : ''
       }`}
-      onClick={() => setIsExpanded(!isExpanded)}
     >
       <div className="p-4">
-        <div className="flex justify-between items-center">
+        <div className="flex justify-between items-start gap-4">
           <div className="flex flex-col items-start gap-1">
             <p className="text-lg font-bold text-text-primary">
               <span className="mr-2 text-xl">{feed.food?.emoji}</span>
@@ -65,7 +116,7 @@ export default function FeedItem({ feed }: FeedItemProps) {
           </div>
           <div className="flex flex-col items-end gap-1">
             <p className="text-lg font-bold text-text-primary">
-              <span className="text-text-muted text-sm mr-1">{feed.food?.unit?.emoji}</span> 
+              <span className="text-text-muted text-sm mr-1">{feed.food?.unit?.emoji}</span>
               {feed.amount} <span className="text-sm font-medium text-text-secondary">{feed.food?.unit?.name || 'ml'}</span>
             </p>
             <p className="text-xs font-medium text-text-muted uppercase tracking-wider">
@@ -79,29 +130,106 @@ export default function FeedItem({ feed }: FeedItemProps) {
             od posl. krmení: {feed.timeSinceLastFeed}
           </p>
         )}
+
+        <div className="mt-4 grid grid-cols-2 gap-2">
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={() => setIsEditing(true)}
+          >
+            Upravit
+          </Button>
+          <Button
+            type="button"
+            variant="danger"
+            size="sm"
+            loading={deleteFeed.isPending}
+            onClick={handleDelete}
+          >
+            Smazat
+          </Button>
+        </div>
       </div>
 
-      <AnimatePresence>
-        {isExpanded && (
-          <motion.div
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: 'auto', opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            className="border-t border-bg-elevated/50"
-          >
-            <div className="p-3 flex justify-end bg-error/5">
-              <button
-                onClick={handleDelete}
-                disabled={deleteFeed.isPending}
-                className="flex items-center gap-2 px-4 py-2 bg-error text-white rounded-lg text-sm font-bold active:scale-95 transition-transform disabled:opacity-50"
-              >
-                <FaTrash />
-                {deleteFeed.isPending ? 'Mažu...' : 'Smazat krmení'}
-              </button>
+      {isEditing && (
+        <div className="border-t border-bg-elevated/50 p-4">
+          <form onSubmit={handleUpdate} className="space-y-4">
+            <SegmentedControl
+              options={[
+                { label: 'Hlavní chody', value: 'main' },
+                { label: 'Doplňky', value: 'additional' }
+              ]}
+              value={editType}
+              onChange={setEditType}
+            />
+
+            <div className="space-y-1.5">
+              <label className="block text-sm font-medium text-text-secondary">Čas krmení</label>
+              <input
+                type="datetime-local"
+                required
+                value={editFeedTime}
+                onChange={(e) => setEditFeedTime(e.target.value)}
+                className="w-full p-3 rounded-xl bg-bg-elevated text-text-primary border-none focus:ring-2 focus:ring-accent-primary outline-none"
+              />
             </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
+
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <label className="block text-sm font-medium text-text-secondary">Množství (ml)</label>
+                <input
+                  type="number"
+                  required
+                  min={1}
+                  value={editAmount}
+                  onChange={(e) => setEditAmount(Number(e.target.value))}
+                  className="w-full p-3 rounded-xl bg-bg-elevated text-text-primary border-none focus:ring-2 focus:ring-accent-primary outline-none"
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <label className="block text-sm font-medium text-text-secondary">Jídlo</label>
+                <select
+                  required
+                  value={editFoodId}
+                  onChange={(e) => setEditFoodId(Number(e.target.value))}
+                  className="w-full p-3 rounded-xl bg-bg-elevated text-text-primary border-none focus:ring-2 focus:ring-accent-primary outline-none"
+                >
+                  {sortedFoods.length > 0 ? (
+                    sortedFoods.map((food) => (
+                      <option key={food.id} value={food.id}>
+                        {food.emoji} {food.name}
+                      </option>
+                    ))
+                  ) : (
+                    <option value={feed.foodId}>
+                      {feed.food?.emoji} {feed.food?.name || 'Aktuální jídlo'}
+                    </option>
+                  )}
+                </select>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3 pt-1">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={resetEditForm}
+              >
+                Zrušit
+              </Button>
+              <Button
+                type="submit"
+                variant="primary"
+                loading={updateFeed.isPending}
+              >
+                Uložit
+              </Button>
+            </div>
+          </form>
+        </div>
+      )}
     </Card>
   )
 }

--- a/components/feed/feedList.tsx
+++ b/components/feed/feedList.tsx
@@ -1,9 +1,9 @@
-import { Feed } from "@prisma/client"
 import FeedItem from "./feedItem"
+import type { FeedListItem } from "./feedItem"
 
 
 type FeedListProps = {
-    feeds: Feed[]
+    feeds: FeedListItem[]
 }
 
 export default function FeedList({ feeds }: FeedListProps) {

--- a/components/feed/feedTopStats.tsx
+++ b/components/feed/feedTopStats.tsx
@@ -3,7 +3,7 @@ import { Card } from "../ui/Card"
 
 type FeedTopStatsProps = {
   stats: {
-    timeSinceLastFeed: string
+    timeSinceLastFeed: string | null
     totalMilk: number
     feedCount: number
     feeds: Array<{
@@ -11,7 +11,7 @@ type FeedTopStatsProps = {
       amount: number
       feedTime?: string
       food: {
-        emoji: string
+        emoji: string | null
       }
     }>
   }
@@ -86,6 +86,10 @@ export default function FeedTopStats({ stats, medianTimeDifference }: FeedTopSta
   )
 }
 
-function getFoodEmojis(feeds: Array<{ foodId: number; amount: number; food: { emoji: string } }>): Set<string> {
-  return new Set(feeds.filter(feed => feed.foodId !== 4).map(feed => feed.food.emoji))
+function getFoodEmojis(feeds: Array<{ foodId: number; amount: number; food: { emoji: string | null } }>): Set<string> {
+  return new Set(
+    feeds
+      .filter((feed) => feed.foodId !== 4 && feed.food.emoji)
+      .map((feed) => feed.food.emoji as string)
+  )
 }

--- a/server/routers/feed.ts
+++ b/server/routers/feed.ts
@@ -152,6 +152,34 @@ export const feedRouter = router({
       })
     }),
 
+  update: publicProcedure
+    .input(
+      z.object({
+        id: z.number(),
+        feedTime: z.string(),
+        amount: z.number().min(1),
+        type: z.enum(['main', 'additional']),
+        foodId: z.number(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const feedTime = new Date(input.feedTime)
+
+      if (isNaN(feedTime.getTime())) {
+        throw new Error('Neplatný čas krmení')
+      }
+
+      return ctx.prisma.feed.update({
+        where: { id: input.id },
+        data: {
+          feedTime,
+          amount: input.amount,
+          type: input.type,
+          foodId: input.foodId,
+        },
+      })
+    }),
+
   delete: publicProcedure
     .input(z.object({ id: z.number() }))
     .mutation(async ({ ctx, input }) => {

--- a/server/routers/measurement.ts
+++ b/server/routers/measurement.ts
@@ -1,6 +1,19 @@
 import { z } from 'zod'
 import { publicProcedure, router } from '../trpc'
 
+const MILK_AMOUNT_PER_KG = 150
+const FEEDS_PER_DAY = 6
+
+function calculateMilkAmounts(weight: number) {
+  const dailyMilkAmount = Math.round((weight / 1000) * MILK_AMOUNT_PER_KG)
+
+  return {
+    dailyMilkAmount,
+    feedsPerDay: FEEDS_PER_DAY,
+    averageFeedAmount: Math.round(dailyMilkAmount / FEEDS_PER_DAY),
+  }
+}
+
 export const measurementRouter = router({
   list: publicProcedure
     .input(z.object({
@@ -23,16 +36,33 @@ export const measurementRouter = router({
       // averageFeedAmount = dailyMilkAmount / targetFeeds (usually 6-8, let's use 6 as base or just calculate from weight)
     }))
     .mutation(async ({ ctx, input }) => {
-      const dailyMilkAmount = (input.weight / 1000) * 150
-      const averageFeedAmount = dailyMilkAmount / 6
+      const milkAmounts = calculateMilkAmounts(input.weight)
 
       return ctx.prisma.babyMeasurement.create({
         data: {
           babyId: input.babyId,
           weight: input.weight,
           height: input.height,
-          dailyMilkAmount,
-          averageFeedAmount,
+          ...milkAmounts,
+        },
+      })
+    }),
+
+  update: publicProcedure
+    .input(z.object({
+      id: z.number(),
+      weight: z.number().min(0),
+      height: z.number().min(0),
+    }))
+    .mutation(async ({ ctx, input }) => {
+      const milkAmounts = calculateMilkAmounts(input.weight)
+
+      return ctx.prisma.babyMeasurement.update({
+        where: { id: input.id },
+        data: {
+          weight: input.weight,
+          height: input.height,
+          ...milkAmounts,
         },
       })
     }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a tRPC update mutation for baby measurements with recalculated milk amounts
- add an edit form for existing measurements on the measurements page
- make edit/delete controls visible in the latest measurement and measurement history list
- add a tRPC update mutation for feed records
- make feed edit/delete controls visible on mobile and add inline editing for feed time, amount, type, and food
- show the feed history page in full mode so the editable list is available there
- align feed history/stat component types with nullable values returned from feed stats

## Testing
- `npm run lint` ✅
- `npm run build` ⚠️ compiled successfully, then failed while collecting page data for existing `/api/notify` because VAPID env is missing (`No key set vapidDetails.publicKey`)
- `npx tsc --noEmit` ⚠️ failed on existing unrelated type errors in Next page props, settings, Button/framer-motion, and QStash feed notification code
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2939e60c-ef72-405c-9879-eac96ed44a98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2939e60c-ef72-405c-9879-eac96ed44a98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

