### PR TITLE
Oprava časování upozornění na krmení

### DIFF
--- a/components/feed/AddFeedSheet.tsx
+++ b/components/feed/AddFeedSheet.tsx
@@ -6,6 +6,7 @@ import { Button } from '../ui/Button'
 import { SegmentedControl } from '../ui/SegmentedControl'
 import { format } from 'date-fns'
 
+import { getNotificationDelayMinutes } from '@/lib/utils'
 import { NotificationModal } from './NotificationModal'
 import { usePush } from '../providers/PushProvider'
 
@@ -36,7 +37,7 @@ export function AddFeedSheet({ babyId, averageAmount, remainingAmount, onSuccess
   const utils = trpc.useUtils()
   
   const createFeed = trpc.feed.create.useMutation({
-    onSuccess: async () => {
+    onSuccess: async (_data, variables) => {
       utils.feed.getStats.invalidate()
       utils.baby.getById.invalidate()
       
@@ -56,7 +57,7 @@ export function AddFeedSheet({ babyId, averageAmount, remainingAmount, onSuccess
           const hours = parseFloat(localStorage.getItem('notify-hours') || '2.5')
           scheduleNotification.mutate({
             subscription: sub,
-            delayMinutes: Math.round(hours * 60),
+            delayMinutes: getNotificationDelayMinutes(variables.feedTime, hours),
             title: '🍼 Čas na krmení!',
             message: `Uběhlo ${hours}h od posledního krmení. Je čas nakrmit miminko.`
           })
@@ -162,6 +163,7 @@ export function AddFeedSheet({ babyId, averageAmount, remainingAmount, onSuccess
         onComplete={() => {
           // Additional logic if needed, but onClose is called anyway
         }}
+        feedTime={feedTime}
         defaultHours={2.5}
       />
     </div>

--- a/components/feed/NotificationModal.tsx
+++ b/components/feed/NotificationModal.tsx
@@ -5,15 +5,17 @@ import { motion, AnimatePresence } from 'framer-motion'
 import { Button } from '../ui/Button'
 import { usePush } from '../providers/PushProvider'
 import { trpc } from '@/trpc/client'
+import { getNotificationDelayMinutes } from '@/lib/utils'
 
 interface NotificationModalProps {
   isOpen: boolean
   onClose: () => void
   onComplete: () => void
+  feedTime: string
   defaultHours?: number
 }
 
-export function NotificationModal({ isOpen, onClose, onComplete, defaultHours = 2.5 }: NotificationModalProps) {
+export function NotificationModal({ isOpen, onClose, onComplete, feedTime, defaultHours = 2.5 }: NotificationModalProps) {
   const { isSupported, isSubscribed, subscribe, subscription } = usePush()
   const scheduleNotification = trpc.feed.scheduleNotification.useMutation()
   
@@ -41,10 +43,10 @@ export function NotificationModal({ isOpen, onClose, onComplete, defaultHours = 
       localStorage.setItem('notify-hours', hours.toString())
     }
 
-    // Schedule via QStash
+    // Schedule via QStash — delay from feed time, not from when user confirms
     scheduleNotification.mutate({
       subscription: sub,
-      delayMinutes: Math.round(hours * 60),
+      delayMinutes: getNotificationDelayMinutes(feedTime, hours),
       title: '🍼 Čas na krmení!',
       message: `Uběhlo ${hours}h od posledního krmení. Je čas nakrmit miminko.`
     }, {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -27,3 +27,18 @@ export function formatDuration(durationMs: number) {
 export function getDeviceTimeZone() {
   return Intl.DateTimeFormat().resolvedOptions().timeZone;
 }
+
+// Minutes until feedTime + intervalHours; falls back to full interval if feedTime is invalid
+export function getNotificationDelayMinutes(
+  feedTime: Date | string,
+  intervalHours: number
+): number {
+  const feedAt = new Date(feedTime);
+  if (isNaN(feedAt.getTime())) {
+    return Math.round(intervalHours * 60);
+  }
+
+  const notifyAt = feedAt.getTime() + intervalHours * 60 * 60 * 1000;
+  const delayMinutes = Math.round((notifyAt - Date.now()) / 60000);
+  return Math.max(1, delayMinutes);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problém

Upozornění mělo přijít v **17:30**, ale dorazilo až v **18:15** — zpoždění přesně **45 minut**.

## Příčina

Notifikace se plánovaly přes QStash jako „za X hodin od teď“ (od okamžiku uložení krmení nebo potvrzení v modalu), nikoli od zadaného **času krmení**.

Typický scénář s výchozím intervalem 2,5 h:
- Krmení v **15:00**, uložení do aplikace v **15:45**
- Očekávání: 15:00 + 2,5 h = **17:30**
- Skutečnost (před opravou): 15:45 + 2,5 h = **18:15**

## Řešení

Přidána funkce `getNotificationDelayMinutes()`, která počítá zpoždění jako `(čas krmení + interval) − teď`.

Použita v:
- automatickém plánování po uložení (`always_yes`)
- modalu pro potvrzení upozornění

## Testování

- [x] Kompilace Next.js buildu prošla
- [ ] Manuální ověření: uložit krmení s časem v minulosti a ověřit, že notifikace přijde v `feedTime + interval`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87801d26-9d52-4a49-b983-77396e6707ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87801d26-9d52-4a49-b983-77396e6707ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

